### PR TITLE
Use `--no-use` option instead of `--install`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,7 @@ jobs:
             sed -i -e 's/ --no-use//' $BASH_ENV
       - run:
           name: Verify
-          command: |
-            node -v
-            npm -v
-            echo '{}' > package.json
-            npm install lodash
+          command: node -v && npm -v
+      - run: echo '{}' > package.json
+      - run: npm install lodash
+      - run: npm uninstall lodash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,15 @@ jobs:
           command: |
             curl --silent -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
-            echo 'source "$NVM_DIR/nvm.sh" --install' >> $BASH_ENV 
+            echo 'source "$NVM_DIR/nvm.sh" --no-use' >> $BASH_ENV 
             source $BASH_ENV
             nvm install --latest-npm --no-progress
             nvm alias default
-            node -v && npm -v
+            sed -i -e 's/ --no-use//' $BASH_ENV
       - run:
           name: Verify
-          command: node -v && npm -v
+          command: |
+            node -v
+            npm -v
+            echo '{}' > package.json
+            npm install lodash


### PR DESCRIPTION
## Why?

The `--install` option always outputs a message like "v12.8.0 is already installed." on each command. It is too noisy. 😩 